### PR TITLE
new property NugetPackageTargetDir that defaults to TargetDir

### DIFF
--- a/MsBuild.NuGet.Pack/tools/MsBuild.NuGet.Pack.targets
+++ b/MsBuild.NuGet.Pack/tools/MsBuild.NuGet.Pack.targets
@@ -36,6 +36,10 @@
     
     <Error Condition="!Exists($(NuGetExePath))" Text="The NuGet commandline was not found at '$(NuGetExePath)'" />
 
+    <PropertyGroup>
+      <NugetPackageTargetDir Condition="'$(NugetPackageTargetDir)' == ''">$(TargetDir)</NugetPackageTargetDir>
+    </PropertyGroup>
+
     <MergeNuSpecTask
       NuSpecPath="$(NuSpecPath)"
       ProjectDirectory="$(ProjectDirectory)"
@@ -46,12 +50,12 @@
       FileExclusionPattern="$(FileExclusionPattern)"
       TargetFrameworkVersion="$(TargetFrameworkVersion)"
       TargetFrameworkProfile="$(TargetFrameworkProfile)" />
-	
+
     <BuildNuSpecTask
       NuGetPath="$(NuGetExePath)"
       NuSpecPath="$(NuSpecPath)"
       ProjectDirectory="$(ProjectDirectory)"
-      OutDir="$(TargetDir)" />
+      OutDir="$(NugetPackageTargetDir)" />
 
   </Target>
 </Project>


### PR DESCRIPTION
Hi Rory,
this is a small change that allows the user to setup a property in the project file (or any msbuild properties file) to have a different output dir for packages than the project's targetdir.

Cheers,
Robert
