### PR TITLE
use UserPrincipal.Current.DisplayName to get the full username

### DIFF
--- a/MsBuild.NuGet.Pack/MergeNuSpecTask.cs
+++ b/MsBuild.NuGet.Pack/MergeNuSpecTask.cs
@@ -73,11 +73,14 @@
         /// <returns>
         ///     The <see cref="string" />.
         /// </returns>
-        private static string GetCurrentUser()
+        private string GetCurrentUser()
         {
-            var fullName = GetFullUserName();
-            if (!string.IsNullOrWhiteSpace(fullName))
-               return fullName;
+            if (!DontUseWindowsDisplayName)
+            {
+                var fullName = GetFullUserName();
+                if (!string.IsNullOrWhiteSpace(fullName))
+                    return fullName; 
+            }
             var fallbackUserName = Environment.UserName;
 
             if (Thread.CurrentPrincipal == null)
@@ -707,6 +710,19 @@
         {
             get;
             set;
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the task should not use <see cref="UserPrincipal.DisplayName"/> to get the full user name. (e.g. in situations with network problems)
+        /// </summary>
+        /// <value>
+        /// <c>false</c> Use <see cref="UserPrincipal.DisplayName"/> to get the full name, <c>true</c> not use <see cref="UserPrincipal.DisplayName"/>, uses the <see cref="System.Security.Principal.IPrincipal.Identity"/> of <see cref="Thread.CurrentPrincipal"/> or <see cref="Environment.UserName"/>
+        /// </value>
+        [Required]
+        public bool DontUseWindowsDisplayName
+        {
+          get;
+          set;
         }
     }
 }

--- a/MsBuild.NuGet.Pack/MergeNuSpecTask.cs
+++ b/MsBuild.NuGet.Pack/MergeNuSpecTask.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
+    using System.DirectoryServices.AccountManagement;
     using System.IO;
     using System.Linq;
     using System.Threading;
@@ -45,6 +46,27 @@
             return true;
         }
 
+
+        static string GetFullUserName()
+        {
+            try
+            {
+                return UserPrincipal.Current.DisplayName;
+            }
+            catch (InvalidOperationException)
+            {
+                return null;
+            }
+            catch (NoMatchingPrincipalException)
+            {
+                return null;
+            }
+            catch (MultipleMatchesException)
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         ///     Gets the current user.
         /// </summary>
@@ -53,6 +75,9 @@
         /// </returns>
         private static string GetCurrentUser()
         {
+            var fullName = GetFullUserName();
+            if (!string.IsNullOrWhiteSpace(fullName))
+               return fullName;
             var fallbackUserName = Environment.UserName;
 
             if (Thread.CurrentPrincipal == null)

--- a/MsBuild.NuGet.Pack/MsBuild.NuGet.Pack.csproj
+++ b/MsBuild.NuGet.Pack/MsBuild.NuGet.Pack.csproj
@@ -34,6 +34,7 @@
     <Reference Include="Microsoft.Build.Utilities.v4.0" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.DirectoryServices.AccountManagement" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/MsBuild.NuGet.Pack/tools/MsBuild.NuGet.Pack.targets
+++ b/MsBuild.NuGet.Pack/tools/MsBuild.NuGet.Pack.targets
@@ -26,6 +26,7 @@
     <ProjectFile Condition="'$(ProjectFile)' == ''">$(MSBuildProjectFile)</ProjectFile>
     <ProjectDirectory Condition="'$(ProjectDirectory)' == ''">$(MSBuildProjectDirectory)</ProjectDirectory>
     <NuSpecPath>$(TargetDir)\$(NuSpecFileName)</NuSpecPath>
+    <DontUseWindowsDisplayName Condition="'$(DontUseWindowsDisplayName)' == ''">false</DontUseWindowsDisplayName>
 
   </PropertyGroup>
 
@@ -46,6 +47,7 @@
       ProjectFile="$(ProjectFile)"
       PrimaryOutputAssembly="$(TargetPath)"
       IncludeBuildVersion="$(IncludeBuildVersion)"
+      DontUseWindowsDisplayName="$(DontUseWindowsDisplayName)"
       UseBuildVersionAsPatch="$(UseBuildVersionAsPatch)"
       FileExclusionPattern="$(FileExclusionPattern)"
       TargetFrameworkVersion="$(TargetFrameworkVersion)"


### PR DESCRIPTION
This is a small change (again) to display the full username using System.DirectoryServices.AccountManagement.UserPrinciple.Current.DisplayName.  
e.g. it will use "Robert Giesecke" instead of "rgiesecke" (@work) or "robert" (@home)

Cheers,
Robert
