### PR TITLE
Use AssemblyInformationalVersionAttribute if it is present and in semantic version format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -187,3 +187,5 @@ FakesAssemblies/
 GeneratedArtifacts/
 _Pvt_Extensions/
 ModelManifest.xml
+/.vs
+/.vs


### PR DESCRIPTION
This patch has MsBuild.NuGet use the contents of the AssemblyInformationalVersionAttribute, if and only ig they are in semantic version format, as the version of the NuGet package rather than deriving it from ProductVersion or FileVersion. This is convenient for building prerelease NuGet packages, since AIVA can incorporate the "-pre", etc., portion of the semantic version which the others cannot, and which doesn't require setting the PackageVersion explicitly, undesirable for CI builds.

I hope you find it useful!
