### PR TITLE
Separate package target directory from nuspec base path

### DIFF
--- a/MsBuild.NuGet.Pack/BuildNuSpecTask.cs
+++ b/MsBuild.NuGet.Pack/BuildNuSpecTask.cs
@@ -15,7 +15,9 @@
         {
             var processInfo = new ProcessStartInfo(NuGetPath)
             {
-                Arguments = "pack \"" + NuSpecPath + "\" -OutputDirectory \"" + OutDir + " \" -BasePath \"" + OutDir + " \" -NoPackageAnalysis -NonInteractive -Verbosity Detailed",
+                Arguments =
+                    "pack \"" + NuSpecPath + "\" -OutputDirectory \"" + OutDir + " \" -BasePath \"" + NuSpecBasePath +
+                    " \" -NoPackageAnalysis -NonInteractive -Verbosity Detailed",
                 CreateNoWindow = true,
                 RedirectStandardError = true,
                 RedirectStandardOutput = true,
@@ -98,6 +100,19 @@
         /// </value>
         [Required]
         public string NuGetPath
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        ///     Gets or sets the base path used for file references in the nuspec file.
+        /// </summary>
+        /// <value>
+        ///     The nuspec base path.
+        /// </value>
+        [Required]
+        public string NuSpecBasePath
         {
             get;
             set;

--- a/MsBuild.NuGet.Pack/tools/MsBuild.NuGet.Pack.targets
+++ b/MsBuild.NuGet.Pack/tools/MsBuild.NuGet.Pack.targets
@@ -40,6 +40,8 @@
     <SourceNuSpecPath>$(ProjectDirectory)\$(NuSpecFileName)</SourceNuSpecPath>
     <TargetNuSpecPath>$(ProjectDirectory)\$(IntermediateOutputPath)\$(NuSpecFileName)</TargetNuSpecPath>
     <NugetPackageTargetDir Condition="'$(NugetPackageTargetDir)' == ''">$(TargetDir)</NugetPackageTargetDir>
+    <NuSpecBasePath Condition="'$(NuSpecBasePath)' == ''">$(NugetPackageTargetDir)</NuSpecBasePath>
+    <NugetPackageOutDir Condition="'$(NugetPackageOutDir)' == ''">$(NugetPackageTargetDir)</NugetPackageOutDir>
 
     <RunNuGetPublish Condition="'$(RunNuGetPublish)'==''">false</RunNuGetPublish>
     <NuGetServer Condition="'$(NuGetServer)' == ''"></NuGetServer>
@@ -82,8 +84,9 @@
     <BuildNuSpecTask
       NuGetPath="$(NuGetExePath)"
       NuSpecPath="$(TargetNuSpecPath)"
+      NuSpecBasePath="$(NuSpecBasePath)"
       ProjectDirectory="$(ProjectDirectory)"
-      OutDir="$(NugetPackageTargetDir)" />
+      OutDir="$(NugetPackageOutDir)" />
 
   </Target>
 


### PR DESCRIPTION
When building multiple projects it is reasonable to assume that they will
each have their own TargetDir, from which files should be packaged.
However it is useful to be able to specify a single output directory for
all built packages by overriding the OutDir.

This change maintains compatibility with existing build scripts which use
NugetPackageTargetDir to mean both the source of files and the package's
destination.
New scripts may override the NuSpecBasePath to specify the source location
for packaged files, and override the package destination by specifying
NugetPackageOutDir.

Refers to #17